### PR TITLE
Fix a partial arg match warning

### DIFF
--- a/R/github-pat.R
+++ b/R/github-pat.R
@@ -33,7 +33,7 @@ set_github_pat <- function(force_new = FALSE, verbose = TRUE){
       } else {
         hx <- curl::handle_setheaders(curl::new_handle(), Authorization = paste("token", cred$password))
         req <- curl::curl_fetch_memory("https://api.github.com/user", handle = hx)
-        if(req$status >= 400){
+        if(req$status_code >= 400){
           message("Authentication failed. Token invalid.")
           credential_reject(cred)
         } else {


### PR DESCRIPTION
I've put `credentials::set_github_pat(verbose = FALSE)` in my `.Rprofile`, which is quite nifty. But I also always have partial match warnings turned on and so I see this at startup:

```
Warning messages:
1: partial match of 'status' to 'status_code' 
2: partial match of 'status' to 'status_code' 
3: partial match of 'status' to 'status_code'
```