### PR TITLE
Introduce `url` argument for `set_github_pat()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: credentials
 Type: Package
 Title: Tools for Managing SSH and Git Credentials
-Version: 1.2.1.1
+Version: 1.2.1.2
 Authors@R: person("Jeroen", "Ooms", role = c("aut", "cre"), 
     email = "jeroen@berkeley.edu", comment = c(ORCID = "0000-0002-4035-0289"))
 Description: Setup and retrieve HTTPS and SSH credentials for use with 'git' and 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+1.2.1.2
+  - set_github_pat() gains a `url` argument, which adds support for GitHub Enterprise.
+  - set_github_pat() now stores the PAT with actual username, instead of the "token" placeholder.
+
+1.2.1.1
+
 1.2.1
   - Quote path to $GIT_ASKTOKEN, for example when credentials is installed in "Program Files"
   - Fix for set_github_pat() token prompt in R.app on MacOS

--- a/R/github-pat.R
+++ b/R/github-pat.R
@@ -1,9 +1,9 @@
 #' Set your Github Personal Access Token
 #'
-#' Populates the `GITHUB_PAT` environment variable using the [git_credential][http_credentials]
-#' manager, which `git` itself uses for storing passwords. The credential manager
-#' returns stored credentials if available, and securely prompt the user for
-#' credentials when needed.
+#' Populates the `GITHUB_PAT` environment variable using a token stored with the
+#' [git_credential][http_credentials] manager, which `git` itself uses for
+#' storing passwords. The credential manager returns stored credentials if
+#' available, and securely prompts the user for credentials when needed.
 #'
 #' Packages that require a `GITHUB_PAT` can call this function to automatically
 #' set the `GITHUB_PAT` when needed. Users may call this function in their
@@ -11,14 +11,39 @@
 #' session without hardcoding any tokens on disk in plain-text.
 #'
 #' @export
-#' @param force_new forget existing pat, always ask for new one.
-#' @param validate checks with the github API that this token works. Defaults to
-#' `TRUE` only in an interactive R session (not when running e.g. CMD check).
-#' @param verbose prints a message showing the credential helper and PAT owner.
-#' @return Returns `TRUE` if a valid GITHUB_PAT was set, and FALSE if not.
-set_github_pat <- function(force_new = FALSE, validate = interactive(), verbose = validate){
+#'
+#' @param url A URL that conveys login information, such as protocol (e.g.
+#'   "https"), remote hostname (e.g. "github.com" or
+#'   "github.starkindustries.com"), and username (e.g. "tony"). See the
+#'   input/output documentation for the [`git-credential`
+#'   command](https://git-scm.com/docs/git-credential#IOFMT) for acceptable
+#'   formats.
+#' @param force_new Clear any existing, matching PAT from the store and
+#'   re-prompt the user.
+#' @param validate Whether to query the `/user` endpoint of the GitHub API to
+#'   confirm that the token works. Defaults to `TRUE` only in an interactive R
+#'   session (not when running e.g. CMD check). This API call respects a host
+#'   that is not "github.com", i.e. it works for GitHub Enterprise.
+#' @param verbose Whether to print a message revealing, e.g., the host, the PAT
+#'   owner's username, and the associated credential helper.
+#'
+#' @return Returns `TRUE` if `GITHUB_PAT` was set, and FALSE otherwise.
+#'
+#' @examples
+#' \dontrun{
+#' set_github_pat()
+#'
+#' set_github_pat("https://github.starkindustries.com")
+#'
+#' set_github_pat("https://tony@github.starkindustries.com")
+#' }
+set_github_pat <- function(url = "https://github.com",
+                           force_new = FALSE,
+                           validate = interactive(),
+                           verbose = validate){
+  # TODO: insert GITHUB_PAT_USER, if defined
   if(isTRUE(force_new))
-    git_credential_forget('https://token@github.com')
+    git_credential_forget(url)
   if(isTRUE(verbose))
     message("If prompted for GitHub credentials, enter your PAT in the password field")
   askpass <- Sys.getenv('GIT_ASKPASS')
@@ -26,15 +51,15 @@ set_github_pat <- function(force_new = FALSE, validate = interactive(), verbose 
     # Hack to override prompt sentence to say "Token" instead of "Password"
     Sys.setenv(GIT_ASKTOKEN = askpass)
     Sys.setenv(GIT_ASKPASS = system.file('ask_token.sh', package = 'credentials', mustWork = TRUE))
-    Sys.setenv(GIT_ASKTOKEN_NAME = 'Personal Access Token (PAT)')
+    Sys.setenv(
+      GIT_ASKTOKEN_NAME = sprintf('%s Personal Access Token (PAT)', parse_url(url)["host"])
+    )
     on.exit(Sys.setenv(GIT_ASKPASS = askpass), add = TRUE)
     on.exit(Sys.unsetenv('GIT_ASKTOKEN_NAME'), add = TRUE)
     on.exit(Sys.unsetenv('GIT_ASKTOKEN'), add = TRUE)
   }
   for(i in 1:3){
-    # The username doesn't have to be real, Github seems to ignore username for PATs
-    pat_user <- Sys.getenv("GITHUB_PAT_USER", 'token')
-    cred <- git_credential_ask(sprintf('https://%s@github.com', pat_user), verbose = verbose)
+    cred <- git_credential_ask(url, verbose = verbose)
     if(length(cred$password)){
       if(nchar(cred$password) < 40){
         message("Please enter a token in the password field, not your master password! Let's try again :-)")
@@ -44,8 +69,15 @@ set_github_pat <- function(force_new = FALSE, validate = interactive(), verbose 
       }
       if(isTRUE(validate)) {
         hx <- curl::handle_setheaders(curl::new_handle(), Authorization = paste("token", cred$password))
-        req <- curl::curl_fetch_memory("https://api.github.com/user", handle = hx)
+        host <- parse_url(url)["host"]
+        api_url <- switch(
+          host,
+          `github.com` = "https://api.github.com/user",
+          sprintf("https://%s/api/v3/user", host)
+        )
+        req <- curl::curl_fetch_memory(api_url, handle = hx)
         if(req$status_code >= 400){
+          # TODO: ideally we would reveal more about the error; we have the info
           message("Authentication failed. Token invalid.")
           credential_reject(cred)
           next
@@ -53,10 +85,13 @@ set_github_pat <- function(force_new = FALSE, validate = interactive(), verbose 
         if(verbose == TRUE){
           data <- jsonlite::fromJSON(rawToChar(req$content))
           helper <- tryCatch(credential_helper_get()[1], error = function(e){"??"})
-          message(sprintf("Using GITHUB_PAT from %s (credential helper: %s)", data$name, helper))
+          message(sprintf(
+            "Using GITHUB_PAT for %s@%s (credential helper: %s)",
+            data$login, cred$host, helper
+          ))
         }
       }
-      return(Sys.setenv(GITHUB_PAT = cred$password))
+      return(Sys.setenv(GITHUB_PAT = cred$password, GITHUB_PAT_USER = cred$username))
     }
   }
   if(verbose == TRUE){

--- a/R/github-pat.R
+++ b/R/github-pat.R
@@ -37,7 +37,7 @@
 #'
 #' set_github_pat("https://tony@github.starkindustries.com")
 #' }
-set_github_pat <- function(url = "https://github.com",
+set_github_pat <- function(url = "https://token@github.com",
                            force_new = FALSE,
                            validate = interactive(),
                            verbose = validate){

--- a/man/set_github_pat.Rd
+++ b/man/set_github_pat.Rd
@@ -4,28 +4,52 @@
 \alias{set_github_pat}
 \title{Set your Github Personal Access Token}
 \usage{
-set_github_pat(force_new = FALSE, validate = interactive(), verbose = validate)
+set_github_pat(
+  url = "https://github.com",
+  force_new = FALSE,
+  validate = interactive(),
+  verbose = validate
+)
 }
 \arguments{
-\item{force_new}{forget existing pat, always ask for new one.}
+\item{url}{A URL that conveys login information, such as protocol (e.g.
+"https"), remote hostname (e.g. "github.com" or
+"github.starkindustries.com"), and username (e.g. "tony"). See the
+input/output documentation for the \href{https://git-scm.com/docs/git-credential#IOFMT}{\code{git-credential} command} for acceptable
+formats.}
 
-\item{validate}{checks with the github API that this token works. Defaults to
-\code{TRUE} only in an interactive R session (not when running e.g. CMD check).}
+\item{force_new}{Clear any existing, matching PAT from the store and
+re-prompt the user.}
 
-\item{verbose}{prints a message showing the credential helper and PAT owner.}
+\item{validate}{Whether to query the \verb{/user} endpoint of the GitHub API to
+confirm that the token works. Defaults to \code{TRUE} only in an interactive R
+session (not when running e.g. CMD check). This API call respects a host
+that is not "github.com", i.e. it works for GitHub Enterprise.}
+
+\item{verbose}{Whether to print a message revealing, e.g., the host, the PAT
+owner's username, and the associated credential helper.}
 }
 \value{
-Returns \code{TRUE} if a valid GITHUB_PAT was set, and FALSE if not.
+Returns \code{TRUE} if \code{GITHUB_PAT} was set, and FALSE otherwise.
 }
 \description{
-Populates the \code{GITHUB_PAT} environment variable using the \link[=http_credentials]{git_credential}
-manager, which \code{git} itself uses for storing passwords. The credential manager
-returns stored credentials if available, and securely prompt the user for
-credentials when needed.
+Populates the \code{GITHUB_PAT} environment variable using a token stored with the
+\link[=http_credentials]{git_credential} manager, which \code{git} itself uses for
+storing passwords. The credential manager returns stored credentials if
+available, and securely prompts the user for credentials when needed.
 }
 \details{
 Packages that require a \code{GITHUB_PAT} can call this function to automatically
 set the \code{GITHUB_PAT} when needed. Users may call this function in their
 \link[=Startup]{.Rprofile} script to automatically set \code{GITHUB_PAT} for each R
 session without hardcoding any tokens on disk in plain-text.
+}
+\examples{
+\dontrun{
+set_github_pat()
+
+set_github_pat("https://github.starkindustries.com")
+
+set_github_pat("https://tony@github.starkindustries.com")
+}
 }


### PR DESCRIPTION
This clears the way for general GitHub Enterprise support. I also think some of this is an improvement, even separate from that. It's not quite done, but it's already pretty cool and ready for you to take a look. There are few things to discuss.