### PR TITLE
Add url parameter in set_github_pat()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: credentials
 Type: Package
 Title: Tools for Managing SSH and Git Credentials
-Version: 1.3.0
+Version: 1.3.1
 Authors@R: person("Jeroen", "Ooms", role = c("aut", "cre"), 
     email = "jeroen@berkeley.edu", comment = c(ORCID = "0000-0002-4035-0289"))
 Description: Setup and retrieve HTTPS and SSH credentials for use with 'git' and 

--- a/R/onattach.R
+++ b/R/onattach.R
@@ -64,8 +64,12 @@ set_default_cred_helper <- function(){
     invisible(tryCatch({
       credential_helper_get()
     }, error = function(...){
-      helper <- credential_helper_list()[1]
-      credential_helper_set(helper, global = TRUE)
+      tryCatch({
+        helper <- credential_helper_list()[1]
+        credential_helper_set(helper, global = TRUE)
+      }, error = function(e){
+        packageStartupMessage(e$message)
+      })
     }))
   }
 }

--- a/man/set_github_pat.Rd
+++ b/man/set_github_pat.Rd
@@ -4,10 +4,17 @@
 \alias{set_github_pat}
 \title{Set your Github Personal Access Token}
 \usage{
-set_github_pat(force_new = FALSE, validate = interactive(), verbose = validate)
+set_github_pat(
+  force_new = FALSE,
+  url = "https://api.github.com",
+  validate = interactive(),
+  verbose = validate
+)
 }
 \arguments{
 \item{force_new}{forget existing pat, always ask for new one.}
+
+\item{url}{a custom server for GitHub Enterprise users.}
 
 \item{validate}{checks with the github API that this token works. Defaults to
 \code{TRUE} only in an interactive R session (not when running e.g. CMD check).}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(credentials)
+
+test_check("credentials")

--- a/tests/testthat/test-github-pat.R
+++ b/tests/testthat/test-github-pat.R
@@ -1,0 +1,21 @@
+test_that("parsing github_pat urls", {
+  # The default
+  out <- get_pat_credential_url('https://api.github.com')
+  expect_equal(out$url, 'https://PersonalAccessToken@github.com')
+  expect_equal(out$var, 'GITHUB_PAT')
+
+  # Custom enterprise server
+  out <- get_pat_credential_url('https://github.ucla.eu/api/v3')
+  expect_equal(out$url, 'https://PersonalAccessToken@github.ucla.eu')
+  expect_equal(out$var, 'GITHUB_PAT_github_ucla_eu')
+
+  # With a custom token 'key' (i.e. username)
+  out <- get_pat_credential_url('https://dummy@api.github.com')
+  expect_equal(out$url, 'https://dummy@github.com')
+  expect_equal(out$var, 'GITHUB_PAT')
+
+  # With a custom token 'key' and Server
+  out <- get_pat_credential_url('https://dummy@github.ucla.eu/api/v3')
+  expect_equal(out$url, 'https://dummy@github.ucla.eu')
+  expect_equal(out$var, 'GITHUB_PAT_github_ucla_eu')
+})


### PR DESCRIPTION
Many open questions:

 - Should we support usernames in the url? Not all managers allow this, GCM-core always overrides the username. Update: gabor suggests using `GCM_AUTHORITY=Basic`.
 - Should we slugify the username? I think not, so that I can do `set_github_pat(url = "https://dummy@github.com")` and have that as my new `GITHUB_PAT`.
 - Currently we require the full API in the url, so the user needs to specify like: `set_github_pat(url = "https://github.ucla.edu/api/v3/")`. Alternatively we could let the user just specify the `hostname` part from the [github enterprise docs](https://docs.github.com/en/enterprise/2.21/user/rest/reference/enterprise-admin) because everything else is fixed.